### PR TITLE
Fix photography loop and clean CSS

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -5,13 +5,6 @@
   width: 100%;
 }
 
-.hero-image {
-  width: 100%;
-  height: auto;
-  display: block;
-  object-fit: cover;
-  max-height: 400px;
-}
 
 .profile-pic-wrapper {
   position: absolute;
@@ -250,6 +243,7 @@ img.zoom-img {
   margin: 3.5rem auto;
   padding: 0 1rem;
   position: relative;
+  z-index: 1;
 
   .grid {
     column-count: 3;
@@ -339,10 +333,6 @@ img.zoom-img {
 }
 
 
-.photo-gallery {
-  position: relative;
-  z-index: 1;
-}
 
 #lightbox-overlay {
   display: none;
@@ -350,12 +340,12 @@ img.zoom-img {
   inset: 0;
   z-index: 9999;
   background-color: rgba(0, 0, 0, 0.95);
+  justify-content: center;
+  align-items: center;
 }
 
 #lightbox-overlay.show {
   display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
 #lightbox-image {

--- a/photography.html
+++ b/photography.html
@@ -20,7 +20,9 @@ permalink: /photography
 
     <div class="filter-panel" id="filter-panel">
       <button class="filter-option active" data-filter="all">All</button>
-      {% assign photos = site.static_files | where_exp: "file", "file.path contains '/images/photos/'" %}
+      {% assign photos_a = site.static_files | where_exp: 'file', "file.path contains '/images/photos/'" %}
+      {% assign photos_b = site.static_files | where_exp: 'file', "file.path contains 'images/photos/'" %}
+      {% assign photos = photos_a | concat: photos_b | sort: 'path' %}
       {% assign series_list = "" %}
       {% for photo in photos %}
         {% assign parts = photo.path | split: '/' %}


### PR DESCRIPTION
## Summary
- loop over all image series when building photography gallery
- remove unused hero-image style
- merge photo-gallery rules and keep only one block
- center images in lightbox more reliably

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6886a82a1f5483319cab867a3e2eb301