### PR TITLE
Fix lightbox scaling and filtering

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -233,8 +233,11 @@ img.zoom-img {
 }
 
 .lightbox img {
-  max-width: 90%;
-  max-height: 90%;
+  width: auto;
+  height: auto;
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
 }
 
 .lightbox:target {

--- a/photography.html
+++ b/photography.html
@@ -44,9 +44,13 @@ permalink: /photography
 <script>
 const select = document.getElementById('series-select');
 select.addEventListener('change', function() {
+  // Close any open lightbox when switching series
+  location.hash = '_';
   const chosen = this.value;
   document.querySelectorAll('#photo-grid a').forEach(link => {
-    link.style.display = (chosen === 'all' || link.dataset.series === chosen) ? 'inline-block' : 'none';
+    if (!link.classList.contains('lightbox')) {
+      link.style.display = (chosen === 'all' || link.dataset.series === chosen) ? 'inline-block' : 'none';
+    }
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- maintain aspect ratio in lightbox
- reset hash and ignore lightbox anchors when filtering series

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6889439879588331a70fc5ca248aa849